### PR TITLE
feat: Initial draft of portfolio page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-slate
+title: Seakros
+description: Portfolio and profile of Seakros, focusing on computer vision and machine learning.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,9 @@
-<!DOCTYPE html>
-<html>
-<body>
-<h1>Temporary Placeholder</h1>
-<p>Please come back when my creator has actually taken a moment to make me!</p>
-</body>
-</html>
+# Seakros
+
+## About Me
+
+I hold a Bachelor's in Electrical Engineering from McGill University and a DPhil (PhD) in Engineering from the University of Oxford. My doctoral research focused on real-time computer vision, specifically developing algorithms for power-constrained environments, with a thesis centered on depth estimation from stereo cameras.
+
+## Current Interests
+
+My current work continues to be in the exciting field of computer vision. I am particularly interested in the development and application of deep learning techniques to advance vision algorithms.


### PR DESCRIPTION
This commit introduces the first version of the GitHub Pages site.

- Updates `_config.yml` to set the site title to 'Seakros' and adds a descriptive meta tag.
- Replaces the placeholder `index.html` with Markdown content outlining:
    - Your educational background (B.Eng. McGill, DPhil Oxford in Engineering).
    - Your doctoral research focus on real-time computer vision and stereo depth estimation.
    - Your current interests in computer vision algorithms and deep learning.

The content is structured to be rendered by the `jekyll-theme-slate`.